### PR TITLE
Upgrade rate-limiter-flexible to 2.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "nestjs-fastify-rate-limiter",
-  "version": "0.0.1",
+  "name": "nestjs-rate-limiter-fastify",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8872,9 +8872,9 @@
       "dev": true
     },
     "rate-limiter-flexible": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-1.3.2.tgz",
-      "integrity": "sha512-f+xNvGn+52G4nZVok9VB3LTE1kfDmqbnWKRayX5n2k/LEQ7doWrYvzmzFVh7ltmLgwEdEzoYwxGaXlfCjFg4Ag=="
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-2.1.9.tgz",
+      "integrity": "sha512-ueIXEHLZZqDBetuzyMbtSQ1Gh6Y5rw8ULoNuGA7L3xZ6njPIc2oM0ZlmsY9rS8rPU4yvdw7lk6MLbWU7WTNfnQ=="
     },
     "rc": {
       "version": "1.2.8",

--- a/package.json
+++ b/package.json
@@ -1,72 +1,72 @@
 {
-  "name": "nestjs-rate-limiter-fastify",
-  "version": "0.0.3",
-  "description": "A configurable rate limiter for NestJS working for fastify (fork of https://github.com/RyanTheAllmighty/nestjs-rate-limiter)",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/smdehaas/nestjs-rate-limiter.git"
-  },
-  "keywords": [
-    "nestjs",
-    "fastify",
-    "nest",
-    "rate",
-    "limit"
-  ],
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/smdehaas/nestjs-rate-limiter/issues"
-  },
-  "homepage": "https://github.com/smdehaas/nestjs-rate-limiter#readme",
-  "publishConfig": {
-    "access": "public"
-  },
-  "directories": {
-    "lib": "lib"
-  },
-  "scripts": {
-    "prebuild": "rimraf dist/",
-    "build": "tsc -p tsconfig.json",
-    "test": "jest --passWithNoTests",
-    "prepublishOnly": "npm run build",
-    "release": "np"
-  },
-  "husky": {
-    "hooks": {
-      "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
-      "pre-commit": "lint-staged",
-      "pre-push": "npm test"
+    "name": "nestjs-rate-limiter-fastify",
+    "version": "0.0.3",
+    "description": "A configurable rate limiter for NestJS working for fastify (fork of https://github.com/RyanTheAllmighty/nestjs-rate-limiter)",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/smdehaas/nestjs-rate-limiter.git"
+    },
+    "keywords": [
+        "nestjs",
+        "fastify",
+        "nest",
+        "rate",
+        "limit"
+    ],
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/smdehaas/nestjs-rate-limiter/issues"
+    },
+    "homepage": "https://github.com/smdehaas/nestjs-rate-limiter#readme",
+    "publishConfig": {
+        "access": "public"
+    },
+    "directories": {
+        "lib": "lib"
+    },
+    "scripts": {
+        "prebuild": "rimraf dist/",
+        "build": "tsc -p tsconfig.json",
+        "test": "jest --passWithNoTests",
+        "prepublishOnly": "npm run build",
+        "release": "np"
+    },
+    "husky": {
+        "hooks": {
+            "commit-msg": "commitlint -E HUSKY_GIT_PARAMS",
+            "pre-commit": "lint-staged",
+            "pre-push": "npm test"
+        }
+    },
+    "lint-staged": {
+        "*.ts": [
+            "prettier --write",
+            "git add -f"
+        ]
+    },
+    "dependencies": {
+        "rate-limiter-flexible": "^2.1.9"
+    },
+    "devDependencies": {
+        "@commitlint/cli": "^8.0.0",
+        "@commitlint/config-conventional": "^8.0.0",
+        "@nestjs/common": "^6.3.1",
+        "@nestjs/core": "^6.3.1",
+        "@types/jest": "^24.0.15",
+        "husky": "^2.4.1",
+        "jest": "^24.8.0",
+        "lint-staged": "^8.2.1",
+        "np": "^5.0.3",
+        "prettier": "^1.19.1",
+        "reflect-metadata": "^0.1.13",
+        "rimraf": "^2.6.3",
+        "rxjs": "^6.5.2",
+        "ts-jest": "^24.0.2",
+        "ts-node": "^8.3.0",
+        "typescript": "^3.9.2"
+    },
+    "peerDependencies": {
+        "@nestjs/common": "^6.0.0",
+        "@nestjs/core": "^6.0.0"
     }
-  },
-  "lint-staged": {
-    "*.ts": [
-      "prettier --write",
-      "git add -f"
-    ]
-  },
-  "dependencies": {
-    "rate-limiter-flexible": "^1.0.2"
-  },
-  "devDependencies": {
-    "@commitlint/cli": "^8.0.0",
-    "@commitlint/config-conventional": "^8.0.0",
-    "@nestjs/common": "^6.3.1",
-    "@nestjs/core": "^6.3.1",
-    "@types/jest": "^24.0.15",
-    "husky": "^2.4.1",
-    "jest": "^24.8.0",
-    "lint-staged": "^8.2.1",
-    "np": "^5.0.3",
-    "prettier": "^1.19.1",
-    "reflect-metadata": "^0.1.13",
-    "rimraf": "^2.6.3",
-    "rxjs": "^6.5.2",
-    "ts-jest": "^24.0.2",
-    "ts-node": "^8.3.0",
-    "typescript": "^3.9.2"
-  },
-  "peerDependencies": {
-    "@nestjs/common": "^6.0.0",
-    "@nestjs/core": "^6.0.0"
-  }
 }


### PR DESCRIPTION
`rate-limiter-flexible` 2.x greatly improves efficiency with Redis and seems to be non-breaking change.

(PS not sure what cause `package.json` reordering but the only actual change is library version)